### PR TITLE
fix lepton indices (+veto condition), added modified tight-tight Z/g veto

### DIFF
--- a/CMGTools/TTHAnalysis/python/tools/leptonJetReCleaner.py
+++ b/CMGTools/TTHAnalysis/python/tools/leptonJetReCleaner.py
@@ -186,7 +186,7 @@ class LeptonJetReCleaner:
                     if l1.charge == l2.charge:
                         flav = abs(l1.pdgId) + abs(l2.pdgId) if byflav else 0
                         ht   = l1.pt + l2.pt
-                        pairs.append( (-flav,-ht,il1,il2) )                    
+                        pairs.append( (-flav,-ht,il1,il2) )
             if len(pairs):
                 pairs.sort()
                 ret = (pairs[0][2],pairs[0][3])


### PR DESCRIPTION
As discussed in the past hours : 
- fixed tight leptons indices
  -kept the full list of tight leptons and defined a temporary list of indices not stored in the trees for 2lss
- added the veto condition when determining the indices
- added the tight-tight dilepton masses 

@gpetruc @cbotta @peruzzim @cheiddegg , if you think it is done in a improper way, let me know
