### PR TITLE
additional adjustments for ra5 synch

### DIFF
--- a/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/susy_2lss_multiiso.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/susy_2lss_multiiso.txt
@@ -1,7 +1,5 @@
 >= 2 good leptons: nLepGood10 >= 2
-#minMllAS8:  minMllAFAS > 8
-#minMllOS12: minMllAFOS <= 0 || minMllAFOS > 12
-#zveto3l:    mZ1 < 76 || mZ1 > 106
+minMllAS8:  minMllAFAS > 8
 exclusive:  nLepGood10 == 2
 anyll: abs(LepGood1_pdgId) > 0 && abs(LepGood2_pdgId) > 0
 same-sign: LepGood1_charge*LepGood2_charge > 0

--- a/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/susy_2lss_sync.sh
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/susy_2lss_sync.sh
@@ -3,7 +3,7 @@
 T="/afs/cern.ch/user/g/gpetrucc/w/TREES_72X_050515_2lssSync"
 #T="/afs/cern.ch/user/g/gpetrucc/w/TREES_72X_210315_NoIso"
 CORE="-P $T --s2v --tree treeProducerSusyMultilepton "
-CORE="${CORE} -F sf/t {P}/1_lepJetReClean_Susy_v3/evVarFriend_{cname}.root"
+CORE="${CORE} -F sf/t {P}/1_lepJetReClean_Susy_v4/evVarFriend_{cname}.root"
 CORE="${CORE} -X exclusive --mcc susy-multilepton/susy_2lssinc_lepchoice_multiiso.txt"
 
 POST="";
@@ -31,7 +31,7 @@ SAVE="${GO}"
 #for LL  in ee em mm ll; do 
 for LL  in ee em mm; do 
 for SR  in 0 10 20 30; do # 0X 1X 2X 3X; do 
-for LPt in hh hl ll; do
+for LPt in hh hl; do
 for MOD in multiiso; do #oldpresel ptrel miniiso; do
 
 GO="${SAVE}"

--- a/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/susy_2lssinc_lepchoice_multiiso.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-multilepton/susy_2lssinc_lepchoice_multiiso.txt
@@ -1,12 +1,9 @@
 LepGood1_(\w+) : LepGood_\1[iL1TV_Mini]; AlsoData
 LepGood2_(\w+) : LepGood_\1[iL2TV_Mini]; AlsoData
 nLepGood10\b: nLepTightVeto10_Mini; AlsoData
-#LepGood1_(\w+) : LepGood_\1[iL1T_Mini]; AlsoData
-#LepGood2_(\w+) : LepGood_\1[iL2T_Mini]; AlsoData
-#nLepGood10\b: nLepGood10_Mini; AlsoData
 \bmZ1\b: mZ1cut10TL_Mini; AlsoData
 minMllAFOS\b: minMllAFOSTL_Mini; AlsoData
-minMllAFAS\b: minMllAFASTL_Mini; AlsoData
+minMllAFAS\b: mllTV_Mini; AlsoData
 nJet40\b: nJet40_Mini; AlsoData
 htJet40j\b: htJet40j_Mini; AlsoData
 nBJetMedium40\b: nBJetMedium40_Mini; AlsoData


### PR DESCRIPTION
@gpetruc @peruzzim @mmarionncern
- add mll variables to apply the mll>8 cut in the workflow
- add the iL1V iL2V indexes in addition to the iL1TV iL2TV, for the application region
- SRTV and SRV are now the definition of the signal regions for the standard cut flow and for the applicaton regions (I've added also the lh and ll SRs)

cristina
